### PR TITLE
config: JPA Auditing 설정 및 soft delete 처리 부 구현

### DIFF
--- a/src/main/java/com/sparta/baedallegend/global/config/jpa/Auditable.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/jpa/Auditable.java
@@ -1,4 +1,4 @@
-package com.sparta.baedallegend.global.config;
+package com.sparta.baedallegend.global.config.jpa;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
@@ -15,7 +15,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class Auditable {
-
     @CreatedBy
     @Column(nullable = false, updatable = false)
     private Long createdBy;
@@ -30,7 +29,11 @@ public abstract class Auditable {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    // TODO : Entity Delete event 발생 시 삭제 관련 메타데이터 처리를 위한 Custom Listener 구현 필요
     private Long deletedBy;
     private LocalDateTime deletedAt;
+
+    public void delete(Long currentUser) {
+        deletedBy = currentUser;
+        deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/sparta/baedallegend/global/config/jpa/JpaConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.sparta.baedallegend.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class JpaConfig {
+}


### PR DESCRIPTION
# 개요
JPA Auditing 사용을 위한 설정을 추가하고, soft delete 시 삭제 관련 필드값 자동 설정을 위한 메서드를 구현합니다.

# 작업 내용
- @EnableJpaAuditing을 적용한 JpaConfig 생성
- Entity에 공통으로 soft delete 관련 필드 값 자동 설정을 위한 메서드 구현

close #5