### PR TITLE
build: Local 환경의 postgreSQL 환경 설정 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,9 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,gradle,macos,windows
 plugin: 플러그 접속식의 전기 제품, 플러그인
+
+## docker postgreSQL volume
+db
+
+## docker compose .env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,gradle,macos,windows
-plugin: 플러그 접속식의 전기 제품, 플러그인
 
 ## docker postgreSQL volume
 db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+Project 실행 방법
+===
+
+## docker를 이용한 local postgreSQL 구동
+1. .env 파일 작성
+```properties
+EXPOSE_PORT=
+TARGET_PORT=5432
+DB_NAME=foody
+USER=
+PASSWORD=
+```
+
+2. docker-compose 구동
+```shell
+docker compose up -d
+```
+
+3. 연결 확인
+> jdbc:postgresql://host.docker.internal:5432/foody

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  foody-db:
+    image: postgres
+    container_name: foody_postgres
+    ports:
+      - ${EXPOSE_PORT}:${TARGET_PORT}
+    volumes:
+      - ./db/postgresql/conf.d:/bitnami/postgresql/conf
+      - ./db/postgresql/data:/bitnami/postgresql
+      - ./db/postgresql/initdb.d:/docker-entrypoint-initdb.d
+    env_file: .env
+    environment:
+      - TZ=Asia/Seoul
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${USER}
+      - POSTGRES_PASSWORD=${PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     ports:
       - ${EXPOSE_PORT}:${TARGET_PORT}
     volumes:
-      - ./db/postgresql/conf.d:/bitnami/postgresql/conf
-      - ./db/postgresql/data:/bitnami/postgresql
+      - ./db/postgresql/conf.d:/etc/postgresql/conf.d
+      - ./db/postgresql:/var/lib/postgresql
       - ./db/postgresql/initdb.d:/docker-entrypoint-initdb.d
     env_file: .env
     environment:


### PR DESCRIPTION
# 개요
local 환경에서 일관된 실행 환경 및 개발 편의성을 위해 docker compose를 이용한 postgreSQL 실행 환경을 구성합니다.

# 작업 내용
- [x] postgreSQL docker-compose.yml 작성
- [x] postgreSQL 실행에 필요한 환경 설정 분리 : .env
- [x] gitignore에 volume 및 .env 추가

## 리뷰 시 참고 사항
1. .env 포맷은 아래와 같습니다.
```properties
EXPOSE_PORT=
TARGET_PORT=5432
DB_NAME=foody
USER=
PASSWORD=
```
2. 실행 방법에 관련된 내용은 README.md에 작성하였습니다.

## 고려사항
현재는 민감한 접속 정보를 포함하는 .evn 파일이 버전 관리 대상에 포함되지 않도록 .gitignore에 등록 되어있어, 각 local 실행 환경에서 docker-compose 실행에 필요한 .env 파일 생성 후 접속 정보를 별도로 작성해야 하는 불편함이 있습니다.

추후 git submodule 혹은 spring cloud config server 등 설정 파일을 분리하는 방법에 대한 논의가 필요할 것 같습니다.

---

closes #22 

