### PR TITLE
Config: profiles 별 Application 구동을 위한 환경 설정 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,15 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    testRuntimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/sparta/baedallegend/BaedalLegendApp.java
+++ b/src/main/java/com/sparta/baedallegend/BaedalLegendApp.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class BaedalLegendApplication {
+public class BaedalLegendApp {
 
     public static void main(String[] args) {
-        SpringApplication.run(BaedalLegendApplication.class, args);
+        SpringApplication.run(BaedalLegendApp.class, args);
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=baedal-legend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles.active: local
+  config:
+    import:
+      - classpath:properties/datasource.yml
+      - classpath:properties/jpa.yml

--- a/src/main/resources/properties/datasource.yml
+++ b/src/main/resources/properties/datasource.yml
@@ -1,0 +1,15 @@
+spring:
+  config.activate.on-profile: test
+  datasource:
+    url: jdbc:h2:mem:test_db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password:
+
+---
+spring:
+  config.activate.on-profile: local
+  datasource:
+    url: jdbc:postgresql://host.docker.internal:5432/foody
+    driver-class-name: org.postgresql.Driver
+    username: foody
+    password: foody

--- a/src/main/resources/properties/jpa.yml
+++ b/src/main/resources/properties/jpa.yml
@@ -1,0 +1,18 @@
+spring:
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+---
+spring:
+  config.activate.on-profile: test
+  jpa:
+    database: postgresql
+    hibernate.ddl-auto: create-drop
+
+---
+spring:
+  config.activate.on-profile: local
+  jpa:
+    hibernate.ddl-auto: update

--- a/src/test/java/com/sparta/baedallegend/BaedalLegendAppTests.java
+++ b/src/test/java/com/sparta/baedallegend/BaedalLegendAppTests.java
@@ -2,9 +2,11 @@ package com.sparta.baedallegend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
-class BaedalLegendApplicationTests {
+class BaedalLegendAppTests {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
# 개요
실행 환경에 따라 변경 되는 설정과 외부 연동 정보를 profiles에 따라 분리하고, Application 기동 시 load 되는 application.yml에 해당 내용을 설정합니다. 실행 환경에 따라 application-{profiles}.yml로 네이밍된 여러 환경 설정 파일 운영을 피하기 위해 환경 설정을 분리하여 작성 한 후, 환경 설정의 단일 포인트가 되는 application.yml에서 필요한 설정을 조합하는 방법으로 구성하였습니다.

# 작업 내용
- [x] DB 연동을 위한 h2, postgresql 의존성 추가
- [x] JPA 환경 설정 파일 작성
- [x] DB 연동을 위한 datasource 환경 설정 파일 작성
- [x] profiles 별 환경 설정 분리

---

close #24 