### PR TITLE
feat: 고객 계층 회원 가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/docs/client/user-api.http
+++ b/docs/client/user-api.http
@@ -1,0 +1,12 @@
+POST http://localhost:8080/auth/sign-up
+Content-Type: application/json
+
+{
+  "email": "customer@foody.io",
+  "password": "password",
+  "name": "홍길동",
+  "nickname": "Red홍",
+  "signUpType": "CUSTOMER"
+}
+
+###

--- a/src/main/java/com/sparta/baedallegend/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/baedallegend/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.sparta.baedallegend.auth.controller;
+
+import static com.sparta.baedallegend.global.config.utils.ResponseEntityUtils.created;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.service.SignUpFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+	path = "/auth",
+	consumes = APPLICATION_JSON_VALUE,
+	produces = APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
+public class AuthController {
+
+	private static final String GET_AN_USER_URI = "/user/{id}";
+	private final SignUpFacade signUpFacade;
+
+	@PostMapping("/sign-up")
+	ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
+		return created(
+			GET_AN_USER_URI,
+			signUpFacade.signUp(signUpRequest)
+		);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/controller/model/SignUpRequest.java
+++ b/src/main/java/com/sparta/baedallegend/auth/controller/model/SignUpRequest.java
@@ -1,0 +1,18 @@
+package com.sparta.baedallegend.auth.controller.model;
+
+import com.sparta.baedallegend.user.domain.User;
+import com.sparta.baedallegend.user.domain.wrap.Password;
+
+public record SignUpRequest(
+	String email,
+	String password,
+	String name,
+	String nickname,
+	SignUpType signUpType
+) {
+
+	public User toEntity(Password encodedPassword) {
+		return User.of(email, encodedPassword, name, nickname, signUpType);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/controller/model/SignUpType.java
+++ b/src/main/java/com/sparta/baedallegend/auth/controller/model/SignUpType.java
@@ -1,0 +1,21 @@
+package com.sparta.baedallegend.auth.controller.model;
+
+import lombok.Getter;
+
+@Getter
+public enum SignUpType {
+	CUSTOMER("고객"),
+	OWNER("가게 주인"),
+	MANAGER("관리자"),
+	;
+
+	private final String description;
+
+	SignUpType(String description) {
+		this.description = description;
+	}
+
+	public boolean isCustomer() {
+		return this == CUSTOMER;
+	}
+}

--- a/src/main/java/com/sparta/baedallegend/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sparta/baedallegend/auth/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.sparta.baedallegend.auth.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthErrorCode {
+	DUPLICATED_EMAIL(BAD_REQUEST, "이미 존재하는 이메일 입니다. : [%s]"),
+	DUPLICATED_NICKNAME(BAD_REQUEST, "이미 존재하는 닉네임 입니다. : [%s]"),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	AuthErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/sparta/baedallegend/auth/exception/AuthException.java
+++ b/src/main/java/com/sparta/baedallegend/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package com.sparta.baedallegend.auth.exception;
+
+public class AuthException extends RuntimeException {
+
+	private final AuthErrorCode code;
+
+	public AuthException(AuthErrorCode code, String... args) {
+		super(formattedMessage(code.getMessage(), args));
+		this.code = code;
+	}
+
+	private static String formattedMessage(String message, String... args) {
+		return message.formatted(args);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/service/CreateUserService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/CreateUserService.java
@@ -1,0 +1,12 @@
+package com.sparta.baedallegend.auth.service;
+
+import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.controller.model.SignUpType;
+
+public interface CreateUserService {
+
+	Long createUser(SignUpRequest signUpRequest);
+
+	boolean isMatched(SignUpType signUpType);
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/service/CustomerCreateService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/CustomerCreateService.java
@@ -1,0 +1,40 @@
+package com.sparta.baedallegend.auth.service;
+
+import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.controller.model.SignUpType;
+import com.sparta.baedallegend.user.domain.User;
+import com.sparta.baedallegend.user.domain.wrap.Password;
+import com.sparta.baedallegend.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomerCreateService implements CreateUserService {
+
+	private final UserRepo userRepo;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	@Override
+	public Long createUser(SignUpRequest signUpRequest) {
+		Password encodedPassword = encryptPassword(signUpRequest.password());
+		User savedUser = userRepo.save(signUpRequest.toEntity(encodedPassword));
+
+		return savedUser.getId();
+	}
+
+	@Override
+	public boolean isMatched(SignUpType signUpType) {
+		return signUpType.isCustomer();
+	}
+
+	private Password encryptPassword(String password) {
+		String encodePassword = passwordEncoder.encode(password);
+		return Password.from(encodePassword);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/service/SignUpFacade.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/SignUpFacade.java
@@ -1,0 +1,46 @@
+package com.sparta.baedallegend.auth.service;
+
+import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.exception.AuthErrorCode;
+import com.sparta.baedallegend.auth.exception.AuthException;
+import com.sparta.baedallegend.user.repo.UserRepo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SignUpFacade {
+
+	private final UserRepo userRepo;
+	private final List<CreateUserService> createUserServices;
+
+	public Long signUp(SignUpRequest signUpRequest) {
+		validate(signUpRequest);
+
+		return createUserServices.stream()
+			.filter(it -> it.isMatched(signUpRequest.signUpType()))
+			.findAny()
+			.orElseThrow()
+			.createUser(signUpRequest)
+			;
+	}
+
+	private void validate(SignUpRequest signUpRequest) {
+		validateDuplicatedEmail(signUpRequest.email());
+		validateDuplicatedNickname(signUpRequest.nickname());
+	}
+
+	private void validateDuplicatedEmail(String email) {
+		if (userRepo.existsByEmail(email)) {
+			throw new AuthException(AuthErrorCode.DUPLICATED_EMAIL, email);
+		}
+	}
+
+	private void validateDuplicatedNickname(String nickname) {
+		if (userRepo.existsByNickname(nickname)) {
+			throw new AuthException(AuthErrorCode.DUPLICATED_NICKNAME, nickname);
+		}
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.baedallegend.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.sparta.baedallegend.global.config.security;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().authenticated()
+			)
+			.build();
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sparta.baedallegend.global.config.security;
 
+import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
 
 			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(POST, "/auth/sign-up").permitAll()
 				.anyRequest().authenticated()
 			)
 			.build();

--- a/src/main/java/com/sparta/baedallegend/global/config/utils/ResponseEntityUtils.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/utils/ResponseEntityUtils.java
@@ -1,0 +1,11 @@
+package com.sparta.baedallegend.global.config.utils;
+
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityUtils {
+
+	public static ResponseEntity<Void> created(String uriFormat, Object path) {
+		return ResponseEntity.created(UriComponentUtils.makeUrl(uriFormat, path)).build();
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
@@ -8,8 +8,8 @@ public class UriComponentUtils {
 	public static <T> URI makeUrl(String baseUri, T path) {
 
 		return UriComponentsBuilder
-			.fromUriString(baseUri) // "/user/{id}
-			.buildAndExpand(path) // 3
+			.fromUriString(baseUri)
+			.buildAndExpand(path)
 			.toUri();
 	}
 

--- a/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
@@ -1,0 +1,16 @@
+package com.sparta.baedallegend.global.config.utils;
+
+import java.net.URI;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class UriComponentUtils {
+
+	public static <T> URI makeUrl(String baseUri, T path) {
+
+		return UriComponentsBuilder
+			.fromUriString(baseUri) // "/user/{id}
+			.buildAndExpand(path) // 3
+			.toUri();
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/domain/Role.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/Role.java
@@ -1,12 +1,17 @@
 package com.sparta.baedallegend.user.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Role {
-     OWNER("고객"), CUSTOMER("가게주인"), MASTER("관리자");
-     private final String description;
-     Role(String description) {
-         this.description = description;
-     }
-     public String getDescription() {
-         return description;
-     }
+	CUSTOMER("고객"),
+	OWNER("가게 주인"),
+	MASTER("관리자"),
+	;
+
+	private final String description;
+
+	Role(String description) {
+		this.description = description;
+	}
 }

--- a/src/main/java/com/sparta/baedallegend/user/domain/User.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/User.java
@@ -1,46 +1,70 @@
 package com.sparta.baedallegend.user.domain;
 
-import jakarta.persistence.*;
+import com.sparta.baedallegend.auth.controller.model.SignUpType;
+import com.sparta.baedallegend.user.domain.wrap.Password;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Table(
-        name = "p_user",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "UK_USER_EMAIL",
-                        columnNames = "email"
-                ),
-                @UniqueConstraint(
-                        name = "UK_USER_NICKNAME",
-                        columnNames = "nickname"
-                )
-        }
+	name = "p_user",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "UK_USER_EMAIL", columnNames = "email"),
+		@UniqueConstraint(name = "UK_USER_NICKNAME", columnNames = "nickname")
+	}
 )
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(nullable = false)
-    private String email;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false, length = 45)
-    private String name;
+	@Column(nullable = false)
+	private String email;
 
-    @Column(nullable = false, length = 45)
-    private String nickname;
+	@Column(nullable = false, length = 45)
+	private String name;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 45)
-    private Role role;
+	@Column(nullable = false, length = 45)
+	private String nickname;
 
-    @Column(nullable = false, length = 200)
-    private String password;
+	@AttributeOverride(name = "value", column = @Column(name = "password"))
+	private Password password;
 
-    // TODO : Auditor 사용을 위한 메타데이터 컬럼들이 구현되지 않았음
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 45)
+	private Role role;
+
+	public User(String email, String name, String nickname, Password password, Role role) {
+		this.email = email;
+		this.name = name;
+		this.nickname = nickname;
+		this.password = password;
+		this.role = role;
+	}
+
+	public static User of(
+		String email,
+		Password encodedPassword,
+		String name,
+		String nickname,
+		SignUpType signUpType
+	) {
+		return new User(email, name, nickname, encodedPassword, Role.valueOf(signUpType.name()));
+	}
+
+	// TODO : Auditor 사용을 위한 메타데이터 컬럼들이 구현되지 않았음
 }

--- a/src/main/java/com/sparta/baedallegend/user/domain/wrap/Password.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/wrap/Password.java
@@ -1,0 +1,26 @@
+package com.sparta.baedallegend.user.domain.wrap;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.annotation.AccessType.Type;
+
+@Getter
+@Embeddable
+@AccessType(Type.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Password {
+
+	@Column(nullable = false)
+	private String value;
+
+	public static Password from(String password) {
+		return new Password(password);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/repo/UserRepo.java
+++ b/src/main/java/com/sparta/baedallegend/user/repo/UserRepo.java
@@ -4,4 +4,9 @@ import com.sparta.baedallegend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepo extends JpaRepository<User, Long> {
+
+	boolean existsByEmail(String email);
+
+	boolean existsByNickname(String nickname);
+
 }

--- a/src/test/java/com/sparta/baedallegend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/baedallegend/auth/controller/AuthControllerTest.java
@@ -1,0 +1,50 @@
+package com.sparta.baedallegend.auth.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.controller.model.SignUpType;
+import com.sparta.baedallegend.auth.service.SignUpFacade;
+import com.sparta.baedallegend.base.WebMvcTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.MimeTypeUtils;
+
+@DisplayName("API:Auth")
+class AuthControllerTest extends WebMvcTestBase {
+
+	@MockBean
+	private SignUpFacade signUpFacade;
+
+	@Test
+	@DisplayName("[로그인][POST:201]")
+	void signUp() throws Exception {
+		// Given
+		final String uri = "/auth/sign-up";
+		SignUpRequest signUpRequest = new SignUpRequest(
+			"customer@foody.io",
+			"password",
+			"홍길동",
+			"Red홍",
+			SignUpType.CUSTOMER
+		);
+		given(signUpFacade.signUp(signUpRequest)).willReturn(1L);
+
+		// When
+		ResultActions resultActions = mockMvc.perform(post(uri)
+			.contentType(MimeTypeUtils.APPLICATION_JSON_VALUE)
+			.accept(MimeTypeUtils.APPLICATION_JSON_VALUE)
+			.content(objectMapper.writeValueAsBytes(signUpRequest))
+		);
+
+		// Then
+		resultActions.andDo(print())
+			.andExpect(status().isCreated());
+	}
+
+}

--- a/src/test/java/com/sparta/baedallegend/base/TestBase.java
+++ b/src/test/java/com/sparta/baedallegend/base/TestBase.java
@@ -1,0 +1,15 @@
+package com.sparta.baedallegend.base;
+
+import static com.sparta.baedallegend.base.TestBase.TEST;
+import static org.springframework.test.context.TestConstructor.AutowireMode.ALL;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@ActiveProfiles(TEST)
+@TestConstructor(autowireMode = ALL)
+public class TestBase {
+
+	static final String TEST = "test";
+
+}

--- a/src/test/java/com/sparta/baedallegend/base/WebMvcTestBase.java
+++ b/src/test/java/com/sparta/baedallegend/base/WebMvcTestBase.java
@@ -1,0 +1,25 @@
+package com.sparta.baedallegend.base;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.baedallegend.auth.controller.AuthController;
+import com.sparta.baedallegend.global.config.security.SecurityConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+	AuthController.class
+})
+@Import(SecurityConfig.class)
+@AutoConfigureMockMvc
+public abstract class WebMvcTestBase extends TestBase {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+}


### PR DESCRIPTION
# 🔗 변경 사항이 무엇인지, 어떤 작업 내용을 포함하는지 작성해 주세요.

## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #12 

## ✏️ 변경 사항은 무엇인가요?


## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- [x] 📌 Spring Security 의존성 추가 및 기본 보안 정책 Configuration 설정
- [x] 📌 회원 계층 별 회원 가입 로직 분리를 위한 CreateUserService interface 정의
- [x] 📌 Controller <-> CreateUserService 연결을 위한 SignUpFacade 계층 구현
- [x] 📌 WebLayer 계층의 손쉬운 TC 작성을 위한 Test Base 설정
- [x] 📌Intellij http client를 이용한 회원 가입 API TC 작성
- [x] 📌@WebMvcTest를 이용한 회원 가입 API TC 작성

## 👀 변경 사항 적용 후 예상 하는 결과를 알려주세요.

> 사용자 계층의 회원 가입 API를 제공합니다.

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> Intellij http client, @WebMvcTest를 이용한 사용자 계층 회원 가입 API 성공 TC 작성

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현 : Service, Repository Layer에 대한 TC 미 작성
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> 고객, 상점 주인, 관리자 등 회원 계층에 따라 회원 가입에 대한 로직이 다를 수 있다고 판단하여 interface로 정의 한 후, 각 계층에 따라 별도로 회원 가입을 처리할 수 있도록 구현 하였습니다. 이 부분에 대해 궁금하거나 부족한 부분이 있다면 말씀해주세요!

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!
