### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/docs/client/user-api.http
+++ b/docs/client/user-api.http
@@ -1,3 +1,4 @@
+## 회원 가입 API
 POST http://localhost:8080/auth/sign-up
 Content-Type: application/json
 
@@ -10,3 +11,12 @@ Content-Type: application/json
 }
 
 ###
+
+## 로그인 API
+POST http://localhost:8080/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": "customer@foody.io",
+  "password": "password"
+}

--- a/src/main/java/com/sparta/baedallegend/BaedalLegendApp.java
+++ b/src/main/java/com/sparta/baedallegend/BaedalLegendApp.java
@@ -1,13 +1,16 @@
 package com.sparta.baedallegend;
 
+import com.sparta.baedallegend.auth.utils.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class BaedalLegendApp {
 
-    public static void main(String[] args) {
-        SpringApplication.run(BaedalLegendApp.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(BaedalLegendApp.class, args);
+	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/baedallegend/auth/controller/AuthController.java
@@ -1,10 +1,14 @@
 package com.sparta.baedallegend.auth.controller;
 
 import static com.sparta.baedallegend.global.config.utils.ResponseEntityUtils.created;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
+import com.sparta.baedallegend.auth.controller.model.SignInRequest;
 import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
+import com.sparta.baedallegend.auth.service.AuthenticationService;
 import com.sparta.baedallegend.auth.service.SignUpFacade;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +27,7 @@ public class AuthController {
 
 	private static final String GET_AN_USER_URI = "/user/{id}";
 	private final SignUpFacade signUpFacade;
+	private final AuthenticationService authenticationService;
 
 	@PostMapping("/sign-up")
 	ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
@@ -30,6 +35,15 @@ public class AuthController {
 			GET_AN_USER_URI,
 			signUpFacade.signUp(signUpRequest)
 		);
+	}
+
+	@PostMapping("/sign-in")
+	ResponseEntity<Void> signIn(
+		@RequestBody SignInRequest signInRequest,
+		HttpServletResponse response
+	) {
+		response.setHeader(AUTHORIZATION, authenticationService.authenticate(signInRequest));
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/auth/controller/model/SignInRequest.java
+++ b/src/main/java/com/sparta/baedallegend/auth/controller/model/SignInRequest.java
@@ -1,0 +1,8 @@
+package com.sparta.baedallegend.auth.controller.model;
+
+public record SignInRequest(
+	String email,
+	String password
+) {
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
+++ b/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
@@ -2,15 +2,10 @@ package com.sparta.baedallegend.auth.domain;
 
 import com.sparta.baedallegend.user.domain.Role;
 
-public class FoodyPrincipal {
-
-	private Long id;
-	private Role role;
-
-	private FoodyPrincipal(Long id, Role role) {
-		this.id = id;
-		this.role = role;
-	}
+public record FoodyPrincipal(
+	Long id,
+	Role role
+) {
 
 	public static FoodyPrincipal of(Long id, Role role) {
 		return new FoodyPrincipal(id, role);

--- a/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
+++ b/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
@@ -1,0 +1,19 @@
+package com.sparta.baedallegend.auth.domain;
+
+import com.sparta.baedallegend.user.domain.Role;
+
+public class FoodyPrincipal {
+
+	private Long id;
+	private Role role;
+
+	private FoodyPrincipal(Long id, Role role) {
+		this.id = id;
+		this.role = role;
+	}
+
+	public static FoodyPrincipal of(Long id, Role role) {
+		return new FoodyPrincipal(id, role);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/sparta/baedallegend/auth/exception/AuthErrorCode.java
@@ -1,6 +1,7 @@
 package com.sparta.baedallegend.auth.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -9,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode {
 	DUPLICATED_EMAIL(BAD_REQUEST, "이미 존재하는 이메일 입니다. : [%s]"),
 	DUPLICATED_NICKNAME(BAD_REQUEST, "이미 존재하는 닉네임 입니다. : [%s]"),
-	;
+
+	BAD_CREDENTIALS(UNAUTHORIZED, "사용자 정보가 잘못 되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
@@ -1,0 +1,47 @@
+package com.sparta.baedallegend.auth.service;
+
+import com.sparta.baedallegend.auth.controller.model.SignInRequest;
+import com.sparta.baedallegend.auth.domain.FoodyPrincipal;
+import com.sparta.baedallegend.auth.exception.AuthErrorCode;
+import com.sparta.baedallegend.auth.exception.AuthException;
+import com.sparta.baedallegend.user.domain.User;
+import com.sparta.baedallegend.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+	private final UserRepo userRepo;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenService tokenService;
+
+	public String authenticate(SignInRequest signInRequest) {
+		FoodyPrincipal principal = verifyUser(signInRequest);
+
+		return tokenService.issueAccessToken(principal);
+	}
+
+	private FoodyPrincipal verifyUser(SignInRequest signInRequest) {
+		User user = loadUserByUsername(signInRequest.email());
+		checkPasswordIsMatched(signInRequest, user);
+
+		return FoodyPrincipal.of(user.getId(), user.getRole());
+	}
+
+	private User loadUserByUsername(String email) {
+		return userRepo.findByEmail(email)
+			.orElseThrow(() -> new AuthException(AuthErrorCode.BAD_CREDENTIALS));
+	}
+
+	private void checkPasswordIsMatched(SignInRequest signInRequest, User user) {
+		if (!passwordEncoder.matches(signInRequest.password(), user.getPassword())) {
+			throw new AuthException(AuthErrorCode.BAD_CREDENTIALS);
+		}
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
@@ -22,7 +22,6 @@ public class AuthenticationService {
 
 	public String authenticate(SignInRequest signInRequest) {
 		FoodyPrincipal principal = verifyUser(signInRequest);
-
 		return tokenService.issueAccessToken(principal);
 	}
 

--- a/src/main/java/com/sparta/baedallegend/auth/service/TokenService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/TokenService.java
@@ -1,9 +1,19 @@
 package com.sparta.baedallegend.auth.service;
 
 import com.sparta.baedallegend.auth.domain.FoodyPrincipal;
+import com.sparta.baedallegend.auth.utils.jwt.JwtProperties;
+import com.sparta.baedallegend.auth.utils.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
-public interface TokenService {
+@Service
+@RequiredArgsConstructor
+public class TokenService {
 
-	String issueAccessToken(FoodyPrincipal principal);
+	private final JwtProperties jwtProperties;
+
+	public String issueAccessToken(FoodyPrincipal principal) {
+		return JwtProvider.create(jwtProperties, principal);
+	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/auth/service/TokenService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/TokenService.java
@@ -1,0 +1,9 @@
+package com.sparta.baedallegend.auth.service;
+
+import com.sparta.baedallegend.auth.domain.FoodyPrincipal;
+
+public interface TokenService {
+
+	String issueAccessToken(FoodyPrincipal principal);
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProperties.java
+++ b/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.sparta.baedallegend.auth.utils.jwt;
+
+import static org.springframework.security.config.Elements.JWT;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = JWT)
+public record JwtProperties(
+	@Value("${spring.application.name}") String issuer,
+	String audience,
+	int expirationMinutes,
+	String secretKey
+
+) {
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProvider.java
@@ -1,0 +1,43 @@
+package com.sparta.baedallegend.auth.utils.jwt;
+
+import static com.sparta.baedallegend.auth.utils.jwt.SingingUtils.generateSigningKey;
+
+import com.sparta.baedallegend.auth.domain.FoodyPrincipal;
+import io.jsonwebtoken.Jwts;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import javax.crypto.SecretKey;
+
+public class JwtProvider {
+
+	private static final String ID = "id";
+	private static final String ROLE = "role";
+
+	public static String create(
+		JwtProperties jwtProperties,
+		FoodyPrincipal principal
+	) {
+		SecretKey signingKey = generateSigningKey(jwtProperties.secretKey());
+		Instant issuedAt = Instant.now();
+		Date expirationDate = getExpirationDate(issuedAt, jwtProperties.expirationMinutes());
+
+		return Jwts.builder()
+			.issuer(jwtProperties.issuer())
+			.issuedAt(Date.from(issuedAt))
+			.audience().add(jwtProperties.audience())
+			.and()
+			.claim(ID, principal.id())
+			.claim(ROLE, principal.role())
+			.expiration(expirationDate)
+			.signWith(signingKey)
+			.compact();
+	}
+
+	private static Date getExpirationDate(Instant issuedAt, int expirationMinutes) {
+		Instant expriationInstant = issuedAt
+			.plus(expirationMinutes, ChronoUnit.MINUTES);
+		return Date.from(expriationInstant);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/auth/utils/jwt/SingingUtils.java
+++ b/src/main/java/com/sparta/baedallegend/auth/utils/jwt/SingingUtils.java
@@ -1,0 +1,22 @@
+package com.sparta.baedallegend.auth.utils.jwt;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.jsonwebtoken.security.Keys;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+
+public class SingingUtils {
+
+	public static SecretKey generateSigningKey(String plainSecretKey) {
+		byte[] base64SecretKey = encodeToBase64(plainSecretKey);
+		return Keys.hmacShaKeyFor(base64SecretKey);
+	}
+
+	private static byte[] encodeToBase64(String base64SecretKey) {
+		return Base64.getEncoder()
+			.withoutPadding()
+			.encode(base64SecretKey.getBytes(UTF_8));
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
 
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(POST, "/auth/sign-up").permitAll()
+				.requestMatchers(POST, "/auth/sign-up", "/auth/sign-in").permitAll()
 				.anyRequest().authenticated()
 			)
 			.build();

--- a/src/main/java/com/sparta/baedallegend/user/domain/User.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/User.java
@@ -66,5 +66,9 @@ public class User {
 		return new User(email, name, nickname, encodedPassword, Role.valueOf(signUpType.name()));
 	}
 
+	public String getPassword() {
+		return password.getValue();
+	}
+
 	// TODO : Auditor 사용을 위한 메타데이터 컬럼들이 구현되지 않았음
 }

--- a/src/main/java/com/sparta/baedallegend/user/repo/UserRepo.java
+++ b/src/main/java/com/sparta/baedallegend/user/repo/UserRepo.java
@@ -1,6 +1,7 @@
 package com.sparta.baedallegend.user.repo;
 
 import com.sparta.baedallegend.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepo extends JpaRepository<User, Long> {
@@ -8,5 +9,7 @@ public interface UserRepo extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
 	boolean existsByNickname(String nickname);
+
+	Optional<User> findByEmail(String email);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
+  application.name: foody-app
   profiles.active: local
   config:
     import:
       - classpath:properties/datasource.yml
       - classpath:properties/jpa.yml
+      - classpath:properties/jwt.yml

--- a/src/main/resources/properties/jwt.yml
+++ b/src/main/resources/properties/jwt.yml
@@ -1,0 +1,6 @@
+spring.config.activate.on-profile: local
+jwt:
+  audience: foody-client
+  expiration-minutes: 30
+  secret-key: local-foody-authenticate-secret-key
+---

--- a/src/test/java/com/sparta/baedallegend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/baedallegend/auth/controller/AuthControllerTest.java
@@ -1,12 +1,15 @@
 package com.sparta.baedallegend.auth.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.sparta.baedallegend.auth.controller.model.SignInRequest;
 import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
 import com.sparta.baedallegend.auth.controller.model.SignUpType;
+import com.sparta.baedallegend.auth.service.AuthenticationService;
 import com.sparta.baedallegend.auth.service.SignUpFacade;
 import com.sparta.baedallegend.base.WebMvcTestBase;
 import org.junit.jupiter.api.DisplayName;
@@ -21,8 +24,11 @@ class AuthControllerTest extends WebMvcTestBase {
 	@MockBean
 	private SignUpFacade signUpFacade;
 
+	@MockBean
+	private AuthenticationService authenticationService;
+
 	@Test
-	@DisplayName("[로그인][POST:201]")
+	@DisplayName("[회원 가입][POST:201]")
 	void signUp() throws Exception {
 		// Given
 		final String uri = "/auth/sign-up";
@@ -45,6 +51,30 @@ class AuthControllerTest extends WebMvcTestBase {
 		// Then
 		resultActions.andDo(print())
 			.andExpect(status().isCreated());
+	}
+
+	@Test
+	@DisplayName("[로그인][POST:200]")
+	void signIn() throws Exception {
+		// Given
+		final String uri = "/auth/sign-in";
+		SignInRequest signInRequest = new SignInRequest(
+			"customer@foody.io",
+			"password"
+		);
+
+		given(authenticationService.authenticate(signInRequest)).willReturn(anyString());
+
+		// When
+		ResultActions resultActions = mockMvc.perform(post(uri)
+			.contentType(MimeTypeUtils.APPLICATION_JSON_VALUE)
+			.accept(MimeTypeUtils.APPLICATION_JSON_VALUE)
+			.content(objectMapper.writeValueAsBytes(signInRequest))
+		);
+
+		// Then
+		resultActions.andDo(print())
+			.andExpect(status().isOk());
 	}
 
 }


### PR DESCRIPTION
# 🔗 변경 사항이 무엇인지, 어떤 작업 내용을 포함하는지 작성해 주세요.

## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #33 

## ✏️ 변경 사항은 무엇인가요?

> 로그인 API 구현, jjwt 의존성 추가, 로그인 요청 허용 인가 정책 추가

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- [x] 📌 jjwt를 이용한 JWT 발급 처리 부 구현
- [x] 📌 jwt 발급에 필요한 항목 정의 및 jwt 환경 설정 주입을 위한 @EnableConfigurationProperties 설정 적용
- [x] 📌 로그인 처리를 위한 회원 인증 및 jwt 발급 서비스 구현
- [x] 📌 http-client, WebMvcTest를 이용한 로그인 API TC 작성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현 : Service, Repository Layer에 대한 TC 미 작성
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> 로그인 완료 시 Response Header의 Authorization 항목에 access token이 발급 됩니다!

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---