### PR TITLE
feat: 현재 로그인 사용자 정보의 손쉬운 접근을 위한 Custom annotation 정의

### DIFF
--- a/docs/client/auth-api.http
+++ b/docs/client/auth-api.http
@@ -1,0 +1,27 @@
+## 회원 가입 API
+POST http://localhost:8080/auth/sign-up
+Content-Type: application/json
+
+{
+  "email": "customer@foody.io",
+  "password": "password",
+  "name": "홍길동",
+  "nickname": "Red홍",
+  "signUpType": "CUSTOMER"
+}
+
+###
+
+## 로그인 API
+POST http://localhost:8080/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": "customer@foody.io",
+  "password": "password"
+}
+> {%
+  client.global.set("access_token", response.headers.valueOf("Authorization"))
+%}
+
+###

--- a/docs/client/user-api.http
+++ b/docs/client/user-api.http
@@ -1,22 +1,6 @@
-## 회원 가입 API
-POST http://localhost:8080/auth/sign-up
+## 마이 페이지 API
+GET http://localhost:8080/user/me
 Content-Type: application/json
-
-{
-  "email": "customer@foody.io",
-  "password": "password",
-  "name": "홍길동",
-  "nickname": "Red홍",
-  "signUpType": "CUSTOMER"
-}
+Authorization: Bearer {{access_token}}
 
 ###
-
-## 로그인 API
-POST http://localhost:8080/auth/sign-in
-Content-Type: application/json
-
-{
-  "email": "customer@foody.io",
-  "password": "password"
-}

--- a/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
+++ b/src/main/java/com/sparta/baedallegend/auth/domain/FoodyPrincipal.java
@@ -1,15 +1,13 @@
 package com.sparta.baedallegend.auth.domain;
 
-import com.sparta.baedallegend.user.domain.Role;
-
 public record FoodyPrincipal(
 	Long id,
 	String email,
-	Role role
+	String roleDetails
 ) {
 
-	public static FoodyPrincipal of(Long id, String email, Role role) {
-		return new FoodyPrincipal(id, email, role);
+	public static FoodyPrincipal of(Long id, String email, String roleDetails) {
+		return new FoodyPrincipal(id, email, roleDetails);
 	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/auth/filter/JwtFilter.java
+++ b/src/main/java/com/sparta/baedallegend/auth/filter/JwtFilter.java
@@ -80,8 +80,8 @@ public class JwtFilter extends OncePerRequestFilter {
 	private static UsernamePasswordAuthenticationToken createUsernamePasswordToken(
 		FoodyPrincipal principal
 	) {
-		GrantedAuthority authority = new SimpleGrantedAuthority(principal.role().name());
-		
+		GrantedAuthority authority = new SimpleGrantedAuthority(principal.roleDetails());
+
 		return new UsernamePasswordAuthenticationToken(
 			principal.id(),
 			null,

--- a/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/AuthenticationService.java
@@ -29,7 +29,7 @@ public class AuthenticationService {
 		User user = loadUserByUsername(signInRequest.email());
 		checkPasswordIsMatched(signInRequest, user);
 
-		return FoodyPrincipal.of(user.getId(), user.getEmail(), user.getRole());
+		return FoodyPrincipal.of(user.getId(), user.getEmail(), user.getRoleDetails());
 	}
 
 	public User loadUserByUsername(String email) {

--- a/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtProvider.java
@@ -29,7 +29,7 @@ public class JwtProvider {
 			.audience().add(jwtProperties.audience())
 			.and()
 			.claim(ID, principal.id())
-			.claim(ROLE, principal.role())
+			.claim(ROLE, principal.roleDetails())
 			.claim(EMAIL, principal.email())
 			.expiration(expirationDate)
 			.signWith(signingKey)

--- a/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtResolver.java
+++ b/src/main/java/com/sparta/baedallegend/auth/utils/jwt/JwtResolver.java
@@ -11,7 +11,6 @@ import static com.sparta.baedallegend.auth.utils.jwt.JwtUtils.generateSigningKey
 
 import com.sparta.baedallegend.auth.domain.FoodyPrincipal;
 import com.sparta.baedallegend.auth.exception.AuthException;
-import com.sparta.baedallegend.user.domain.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -60,9 +59,9 @@ public class JwtResolver {
 	private static FoodyPrincipal extractPrincipal(Claims claims) {
 		Long id = claims.get(ID, Long.class);
 		String email = claims.get(EMAIL, String.class);
-		Role role = claims.get(ROLE, Role.class);
+		String roleDetails = claims.get(ROLE, String.class);
 
-		return FoodyPrincipal.of(id, email, role);
+		return FoodyPrincipal.of(id, email, roleDetails);
 	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/global/config/annotations/LoginUser.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/annotations/LoginUser.java
@@ -1,0 +1,14 @@
+package com.sparta.baedallegend.global.config.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this =='anonymousUser' ? null : #this")
+public @interface LoginUser {
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/controller/UserController.java
+++ b/src/main/java/com/sparta/baedallegend/user/controller/UserController.java
@@ -1,4 +1,34 @@
 package com.sparta.baedallegend.user.controller;
 
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+import com.sparta.baedallegend.global.config.annotations.LoginUser;
+import com.sparta.baedallegend.user.controller.model.UserResponse;
+import com.sparta.baedallegend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+	path = "/user",
+	consumes = APPLICATION_JSON_VALUE,
+	produces = APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
 public class UserController {
+
+	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final UserService userService;
+
+	@GetMapping("/me")
+	ResponseEntity<UserResponse> me(@LoginUser Long id) {
+		log.info("[{}]", id);
+		return ResponseEntity.ok(userService.loadUserById(id));
+	}
+
 }

--- a/src/main/java/com/sparta/baedallegend/user/controller/model/UserResponse.java
+++ b/src/main/java/com/sparta/baedallegend/user/controller/model/UserResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.baedallegend.user.controller.model;
+
+import com.sparta.baedallegend.user.domain.User;
+
+public record UserResponse(
+	Long id,
+	String email,
+	String nickname,
+	String roleDetails
+	// TODO Auditor 적용 후 가입일 응답 항목 추가
+) {
+
+	public static UserResponse from(User user) {
+		return new UserResponse(
+			user.getId(),
+			user.getEmail(),
+			user.getNickname(),
+			user.getRoleDetails()
+		);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/domain/User.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/User.java
@@ -70,5 +70,9 @@ public class User {
 		return password.getValue();
 	}
 
+	public String getRoleDetails() {
+		return role.getDescription();
+	}
+
 	// TODO : Auditor 사용을 위한 메타데이터 컬럼들이 구현되지 않았음
 }

--- a/src/main/java/com/sparta/baedallegend/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/baedallegend/user/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.sparta.baedallegend.user.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode {
+	NOT_EXIST(NOT_FOUND, "요청에 해당하는 사용자가 존재하지 않습니다. : [%s]");
+
+	private final HttpStatus status;
+	private final String message;
+
+	UserErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/sparta/baedallegend/user/exception/UserException.java
+++ b/src/main/java/com/sparta/baedallegend/user/exception/UserException.java
@@ -1,0 +1,16 @@
+package com.sparta.baedallegend.user.exception;
+
+public class UserException extends RuntimeException {
+
+	private final UserErrorCode code;
+
+	public UserException(UserErrorCode code, Object... args) {
+		super(formattedMessage(code.getMessage(), args));
+		this.code = code;
+	}
+
+	private static String formattedMessage(String message, Object... args) {
+		return message.formatted(args);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/service/UserService.java
+++ b/src/main/java/com/sparta/baedallegend/user/service/UserService.java
@@ -1,4 +1,28 @@
 package com.sparta.baedallegend.user.service;
 
+import com.sparta.baedallegend.user.controller.model.UserResponse;
+import com.sparta.baedallegend.user.domain.User;
+import com.sparta.baedallegend.user.exception.UserErrorCode;
+import com.sparta.baedallegend.user.exception.UserException;
+import com.sparta.baedallegend.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class UserService {
+
+	private final UserRepo userRepo;
+
+	public UserResponse loadUserById(Long id) {
+		return UserResponse.from(findUser(id));
+	}
+
+	public User findUser(Long id) {
+		return userRepo.findById(id)
+			.orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, id));
+	}
+
 }


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #55 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
JwtFilter를 이용해 인증 과정을 거쳐 SecurityContextHolder의 Authentication 형태로 저장된 현재 로그인 사용자 정보에 손쉽게 접근하기 위한 Custom annotation을 구현하였습니다. 

사용 예제는 아래 커밋에서 확인 하실 수 있습니다.
[마이페이지 조회 API 구현](https://github.com/baedal-legend/foody/commit/ba46a096a7390a173cf657f445294e6c93e58fba)

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 JWT Claim 중 Role 관련 저장 및 파싱 과정에서 발생하는 오류 수정
- 📌 SecurityContextHolder에 저장된 Authentication의 id에 손쉽게 접근하기 위해 @AuthenticationPrincipal 기반의 Custom annotation 구현
- 📌 사용자 마이페이지 API 구현


## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> Intellij http-client를 이용한 마이페이지 API 호출 및 정상 응답 확인

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> @LoginUser를 이용하여 마이페이지 API에 현재 로그인 사용자 정보의 ID를 주입 받을 수 있도록 구현하였습니다. 리뷰에 참고 부탁드려요!

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #55 
