### PR TITLE
feat: #58 User Entity의 Auditor 정의 및 CreatedBy 설정 처리 부 구현

### DIFF
--- a/src/main/java/com/sparta/baedallegend/auth/service/CustomerCreateService.java
+++ b/src/main/java/com/sparta/baedallegend/auth/service/CustomerCreateService.java
@@ -4,7 +4,7 @@ import com.sparta.baedallegend.auth.controller.model.SignUpRequest;
 import com.sparta.baedallegend.auth.controller.model.SignUpType;
 import com.sparta.baedallegend.user.domain.User;
 import com.sparta.baedallegend.user.domain.wrap.Password;
-import com.sparta.baedallegend.user.repo.UserRepo;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,16 +15,24 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerCreateService implements CreateUserService {
 
-	private final UserRepo userRepo;
+	private final EntityManager entityManager;
 	private final PasswordEncoder passwordEncoder;
 
-	@Transactional
 	@Override
 	public Long createUser(SignUpRequest signUpRequest) {
 		Password encodedPassword = encryptPassword(signUpRequest.password());
-		User savedUser = userRepo.save(signUpRequest.toEntity(encodedPassword));
+		User savedUser = saveUser(signUpRequest.toEntity(encodedPassword));
 
 		return savedUser.getId();
+	}
+
+	@Transactional
+	public User saveUser(User user) {
+		entityManager.persist(user);
+		entityManager.flush();
+		user.applyUserCreated(user.getId());
+
+		return user;
 	}
 
 	@Override

--- a/src/main/java/com/sparta/baedallegend/global/config/jpa/Auditable.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/jpa/Auditable.java
@@ -7,33 +7,21 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class Auditable {
-    @CreatedBy
-    @Column(nullable = false, updatable = false)
-    private Long createdBy;
 
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+	@CreatedBy
+	@Column(nullable = false, updatable = false)
+	protected Long createdBy;
 
-    @LastModifiedBy
-    private Long updatedBy;
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+	
+	protected CommonAuditFields auditableFields;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
-    private Long deletedBy;
-    private LocalDateTime deletedAt;
-
-    public void delete(Long currentUser) {
-        deletedBy = currentUser;
-        deletedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/sparta/baedallegend/global/config/jpa/CommonAuditFields.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/jpa/CommonAuditFields.java
@@ -1,0 +1,29 @@
+package com.sparta.baedallegend.global.config.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Embeddable
+public abstract class CommonAuditFields {
+
+	@LastModifiedBy
+	private Long updatedBy;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	@Column(updatable = false)
+	private Long deletedBy;
+
+	@Column(updatable = false)
+	private LocalDateTime deletedAt;
+
+	public void delete(Long currentUser) {
+		deletedBy = currentUser;
+		deletedAt = LocalDateTime.now();
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/user/domain/User.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.sparta.baedallegend.user.domain;
 
 import com.sparta.baedallegend.auth.controller.model.SignUpType;
+import com.sparta.baedallegend.user.domain.auditor.UserAuditable;
 import com.sparta.baedallegend.user.domain.wrap.Password;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
@@ -12,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,7 +28,7 @@ import lombok.NoArgsConstructor;
 )
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends UserAuditable {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,6 +50,10 @@ public class User {
 	@Column(nullable = false, length = 45)
 	private Role role;
 
+	private Long createdBy;
+
+	private LocalDateTime createdAt;
+
 	public User(String email, String name, String nickname, Password password, Role role) {
 		this.email = email;
 		this.name = name;
@@ -64,6 +70,11 @@ public class User {
 		SignUpType signUpType
 	) {
 		return new User(email, name, nickname, encodedPassword, Role.valueOf(signUpType.name()));
+	}
+
+	public void applyUserCreated(Long id) {
+		createdBy = id;
+		createdAt = LocalDateTime.now();
 	}
 
 	public String getPassword() {

--- a/src/main/java/com/sparta/baedallegend/user/domain/auditor/UserAuditable.java
+++ b/src/main/java/com/sparta/baedallegend/user/domain/auditor/UserAuditable.java
@@ -1,0 +1,20 @@
+package com.sparta.baedallegend.user.domain.auditor;
+
+import com.sparta.baedallegend.global.config.jpa.CommonAuditFields;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class UserAuditable {
+
+	protected Long createdBy;
+	protected LocalDateTime createdAt;
+
+	protected CommonAuditFields auditableFields;
+
+}

--- a/src/main/resources/properties/jpa.yml
+++ b/src/main/resources/properties/jpa.yml
@@ -15,3 +15,8 @@ spring:
   config.activate.on-profile: local
   jpa:
     hibernate.ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        highlight_sql: true


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #58 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
최초 비 영속 상태의 User Entity의 CreatedBy에 대해, 동일 트랜잭션 내에서 EntityManger를 이용하여 영속화 이후 DB로 부터 부여 받은 PK를 설정 후 merge 하여 User Entity에 대한 CreatedBy를 설정하도록 구현하였습니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 모든 Entity에 공통으로 적용되는 Auditor 객체 정의
- 📌 User Entity와 그 외 Entity가 사용하기 위한 Auditor 분리
- 📌 회원 가입 시, User Entity의 CreatedBy 설정 부 추가

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> http-client를 이용한 API 호출 후, datagrip을 통해 data 반영 여부를 확인하였습니다.

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #58 
