### PR TITLE
config: 데이터 감사 및 추적을 위한 Auditor 값 자동 설정 Configuration 구성

### DIFF
--- a/src/main/java/com/sparta/baedallegend/global/config/jpa/AuditorAwareConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/jpa/AuditorAwareConfig.java
@@ -1,0 +1,33 @@
+package com.sparta.baedallegend.global.config.jpa;
+
+import static org.springframework.security.config.Elements.ANONYMOUS;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class AuditorAwareConfig {
+
+	@Bean
+	public AuditorAware<Long> auditorAware() {
+		return () -> Optional.of(SecurityContextHolder.getContext())
+			.map(SecurityContext::getAuthentication)
+			.filter(this::isAuthenticated)
+			.map(Authentication::getPrincipal)
+			.map(Long.class::cast);
+	}
+
+	private boolean isAuthenticated(Authentication authentication) {
+		return authentication.isAuthenticated() && isNotAnonymousUser(authentication);
+	}
+
+	private boolean isNotAnonymousUser(Authentication authentication) {
+		return !authentication.getName().contains(ANONYMOUS);
+	}
+
+}


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #57 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
Jpa Auditing Event 처리 시 SecurityContextHodler에 저장된 인증된 사용자 정보를 사용할 수 있도록 AuditorAware에 대한 환경 설정을 구성 하였습니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 JpaAuditorAware 환경 설정 작성 및 등록

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [ ] 🟡 일부 구현
- [x] 🔴 미 작성

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #57 
