### PR TITLE
config: 각 도메인 계층에서 발생하는 예외 단일 처리를 위한 GlobalExceptionHandler 구현

### DIFF
--- a/src/main/java/com/sparta/baedallegend/global/config/exception/BusinessException.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/exception/BusinessException.java
@@ -1,0 +1,31 @@
+package com.sparta.baedallegend.global.config.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+	protected HttpStatus status;
+	private final String code;
+	private final String message;
+
+	public BusinessException(HttpStatus status, String code, String message) {
+		super(message);
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+
+	public BusinessException(HttpStatus status, String code, String message, Object... args) {
+		super(formattingErrorMessage(message, args));
+		this.status = status;
+		this.code = code;
+		this.message = formattingErrorMessage(message, args);
+	}
+
+	private static String formattingErrorMessage(String message, Object... objects) {
+		return message.formatted(objects);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalErrorCode.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalErrorCode.java
@@ -1,0 +1,61 @@
+package com.sparta.baedallegend.global.config.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum GlobalErrorCode {
+	HTTP_MESSAGE_NOT_READABLE(BAD_REQUEST, "요청 값을 확인 할 수 없습니다."),
+	METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST, "요청 값의 자료형이 잘못되었습니다."),
+	METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "잘못된 요청입니다. Request Body를 확인해 주세요."),
+	MISSING_SERVLET_REQUEST_PARAMETER(BAD_REQUEST, "잘못된 요청입니다. Query Parameter를 확인해 주세요."),
+	MISSING_SERVLET_PATH_VARIABLE(BAD_REQUEST, "잘못된 요청입니다. Path URI를 확인해 주세요."),
+	HTTP_MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 요청입니다. Content-Type을 확인해주세요."),
+
+	UNEXPECTED_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생하였습니다."),
+	;
+
+
+	public final HttpStatus status;
+	public final String message;
+
+	GlobalErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public static GlobalErrorCode valueOf(Exception exception) {
+		String errorCodeName = convertExceptionClassNameToErrorCodeName(exception);
+		try {
+			return valueOf(errorCodeName);
+		} catch (IllegalArgumentException e) {
+			return GlobalErrorCode.UNEXPECTED_ERROR;
+		}
+	}
+
+	private static String convertExceptionClassNameToErrorCodeName(Exception exception) {
+		String className = extractExceptionClassName(exception);
+		return convertToErrorCodeName(className);
+	}
+
+	private static String extractExceptionClassName(Exception exception) {
+		return exception.getClass().getSimpleName();
+	}
+
+	private static String convertToErrorCodeName(String className) {
+		String exceptKeyword = "_EXCEPTION";
+		return convertToConstants(className).replace(exceptKeyword, "");
+	}
+
+	private static String convertToConstants(String value) {
+		String regex = "([a-z])([A-Z])";
+		String replacement = "$1_$2";
+
+		return value.replaceAll(regex, replacement)
+			.toUpperCase();
+	}
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalErrorResponse.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalErrorResponse.java
@@ -1,0 +1,40 @@
+package com.sparta.baedallegend.global.config.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+
+public record GlobalErrorResponse(
+	String method,
+	String path,
+	String code,
+	String message,
+	LocalDateTime timestamp
+) {
+
+	public static GlobalErrorResponse of(
+		HttpServletRequest request,
+		GlobalErrorCode errorCode
+	) {
+		return new GlobalErrorResponse(
+			request.getMethod(),
+			request.getRequestURI(),
+			errorCode.name(),
+			errorCode.name(),
+			LocalDateTime.now()
+		);
+	}
+
+	public static GlobalErrorResponse businessErrorOf(
+		HttpServletRequest request,
+		BusinessException exception
+	) {
+		return new GlobalErrorResponse(
+			request.getMethod(),
+			request.getRequestURI(),
+			exception.getCode(),
+			exception.getMessage(),
+			LocalDateTime.now()
+		);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/exception/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.sparta.baedallegend.global.config.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler({
+		HttpMessageNotReadableException.class,
+		MethodArgumentTypeMismatchException.class,
+		HttpRequestMethodNotSupportedException.class,
+		HttpMediaTypeNotAcceptableException.class,
+		HttpMediaTypeNotSupportedException.class,
+		MissingPathVariableException.class,
+		MissingServletRequestParameterException.class
+	})
+	public ResponseEntity<GlobalErrorResponse> invalidRequestException(
+		Exception exception,
+		HttpServletRequest request
+	) {
+		GlobalErrorCode errorCode = GlobalErrorCode.valueOf(exception);
+		GlobalErrorResponse errorResponse = GlobalErrorResponse.of(
+			request,
+			errorCode);
+
+		log.error(errorResponse.toString());
+		
+		return ResponseEntity.status(errorCode.status)
+			.body(errorResponse);
+	}
+
+	@ExceptionHandler({Exception.class, RuntimeException.class})
+	public ResponseEntity<GlobalErrorResponse> unexpectedException(
+		Exception exception,
+		HttpServletRequest request
+	) {
+		GlobalErrorResponse errorResponse = GlobalErrorResponse.of(
+			request,
+			GlobalErrorCode.UNEXPECTED_ERROR
+		);
+
+		exception.printStackTrace();
+
+		return ResponseEntity.internalServerError()
+			.body(errorResponse);
+	}
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<GlobalErrorResponse> businessException(
+		BusinessException exception,
+		HttpServletRequest request
+	) {
+		GlobalErrorResponse globalErrorResponse = GlobalErrorResponse.businessErrorOf(
+			request,
+			exception
+		);
+
+		log.error(globalErrorResponse.toString());
+
+		return ResponseEntity.status(exception.getStatus())
+			.body(globalErrorResponse);
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/utils/UriComponentUtils.java
@@ -6,7 +6,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class UriComponentUtils {
 
 	public static <T> URI makeUrl(String baseUri, T path) {
-
 		return UriComponentsBuilder
 			.fromUriString(baseUri)
 			.buildAndExpand(path)


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #43 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
비지니스 로직 구현 중 발생할 수 있는 예외 상황을 RuntimeException, IllegalArgumentException 등의 포괄적인 예외가 아닌 해당 도메인의 예외 상황을 보다 상세히 표현할 수 있는 Custom Exception과 Custom Error Code를 정의하고, 각 도메인에서 Throw된 Custom Exception Event를 수신하여 오류 응답, 로깅, 알림 등의 일괄적인 처리를 위한 단일 예외 처리부 구현 작업입니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 단일 예외 처리 GlobalExceptionHandler 정의
- 📌 Expected, Unexpected Exception Handler 구현
- 📌 BusinessException Handler 구현
- 📌 공통 에러 응답을 위한 GlobalErrorResponse, GlobalErrorCode 정의

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [ ] 🟡 일부 구현
- [x] 🔴 미 작성

## 💬 리뷰 요구사항

> 각 도메인 계층에서 발생할 수 있는 예외는 Custom Exception을 구현해서 보다 상세하게 처리할 수 있고, 공통 포맷인 BusinessException을 상속 받으면 GlobalExceptionHandler 에 의해 에러 응답 가공 및 로깅 등의 처리를 일관되게 적용 할 수 있습니다. 리뷰에 참고 부탁드려요.

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #43 
