### PR TITLE
feat: Shop 단일 조회 API

### DIFF
--- a/docs/client/shop-api.http
+++ b/docs/client/shop-api.http
@@ -16,3 +16,12 @@ Content-Type: application/json
 ### Shop 전체 조회 API
 GET http://localhost:8080/shop?page=0&size=2
 Authorization: Bearer {{access_token}}
+
+### Shop 단일 조회 API
+GET http://localhost:8080/shop/readOne
+Authorization: Bearer {{access_token}}
+Content-Type: application/json
+
+{
+  "shopId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3acb4d"
+}

--- a/docs/client/shop-api.http
+++ b/docs/client/shop-api.http
@@ -18,10 +18,10 @@ GET http://localhost:8080/shop?page=0&size=2
 Authorization: Bearer {{access_token}}
 
 ### Shop 단일 조회 API
-GET http://localhost:8080/shop/readOne
+GET http://localhost:8080/shop/details
 Authorization: Bearer {{access_token}}
 Content-Type: application/json
 
 {
-  "shopId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3acb4d"
+  "shopId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3acb4"
 }

--- a/src/main/java/com/sparta/baedallegend/menu/domain/MenuStatus.java
+++ b/src/main/java/com/sparta/baedallegend/menu/domain/MenuStatus.java
@@ -1,8 +1,5 @@
 package com.sparta.baedallegend.menu.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.stream.Stream;
-
 public enum MenuStatus {
 	ON_SALE("판매중"), SOLD_OUT("하루품절"), HIDDEN("숨김");
 	private String description;
@@ -11,5 +8,8 @@ public enum MenuStatus {
 		this.description = description;
 	}
 
+	public String getDescription() {
+		return description;
+	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/menu/repo/MenuRepo.java
+++ b/src/main/java/com/sparta/baedallegend/menu/repo/MenuRepo.java
@@ -1,11 +1,16 @@
 package com.sparta.baedallegend.menu.repo;
 
 import com.sparta.baedallegend.menu.domain.Menu;
+import com.sparta.baedallegend.shop.domain.Shop;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.UUID;
-
 @Repository
 public interface MenuRepo extends JpaRepository<Menu, UUID> {
+
+	List<Menu> findByShopAndIsPublicTrue(Shop shop);
+
+
 }

--- a/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
@@ -2,6 +2,8 @@ package com.sparta.baedallegend.shop.controller;
 
 import com.sparta.baedallegend.shop.controller.dto.CreateShopRequest;
 import com.sparta.baedallegend.shop.controller.dto.FindAllShopResponse;
+import com.sparta.baedallegend.shop.controller.dto.ReadOneShopRequest;
+import com.sparta.baedallegend.shop.controller.dto.ReadOneShopResponse;
 import com.sparta.baedallegend.shop.service.ShopService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +47,12 @@ public class ShopController {
 		PageRequest pageRequest = PageRequest.of(page, size);
 		Page<FindAllShopResponse> responses = shopService.findAll(pageRequest);
 		return ResponseEntity.ok().body(responses);
+	}
+
+	@GetMapping("/readOne")
+	public ResponseEntity<ReadOneShopResponse> readOne(@RequestBody ReadOneShopRequest request) {
+		ReadOneShopResponse response = shopService.readOne(request);
+		return ResponseEntity.ok().body(response);
 	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
@@ -49,7 +49,7 @@ public class ShopController {
 		return ResponseEntity.ok().body(responses);
 	}
 
-	@GetMapping("/readOne")
+	@GetMapping("/details")
 	public ResponseEntity<ReadOneShopResponse> readOne(@RequestBody ReadOneShopRequest request) {
 		ReadOneShopResponse response = shopService.readOne(request);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopMenuResponse.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopMenuResponse.java
@@ -1,13 +1,10 @@
 package com.sparta.baedallegend.shop.controller.dto;
 
 import com.sparta.baedallegend.menu.domain.Menu;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ReadOneShopMenuResponse {
 

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopMenuResponse.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopMenuResponse.java
@@ -1,0 +1,25 @@
+package com.sparta.baedallegend.shop.controller.dto;
+
+import com.sparta.baedallegend.menu.domain.Menu;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReadOneShopMenuResponse {
+
+	private String menuId;
+	private String menuName;
+	private int menuPrice;
+	private String menuDescription;
+	private String menuStatus;
+
+	public static ReadOneShopMenuResponse from(Menu menu) {
+		return new ReadOneShopMenuResponse(menu.getId().toString(), menu.getName(), menu.getPrice(),
+			menu.getDescription(), menu.getMenuStatus().getDescription());
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopRequest.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.baedallegend.shop.controller.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReadOneShopRequest {
+
+	private String shopId;
+
+}

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopResponse.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopResponse.java
@@ -1,0 +1,28 @@
+package com.sparta.baedallegend.shop.controller.dto;
+
+import com.sparta.baedallegend.shop.domain.Shop;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReadOneShopResponse {
+
+	private String name;
+	private String phoneNumber;
+	private String description;
+	private String address;
+	private List<ReadOneShopMenuResponse> menus = new ArrayList<>();
+
+	public static ReadOneShopResponse of(Shop shop, List<ReadOneShopMenuResponse> menuResponses) {
+		return new ReadOneShopResponse(shop.getName(),
+			shop.getPhoneNumber(), shop.getDescription(), shop.getAddress(), menuResponses);
+
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopResponse.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/ReadOneShopResponse.java
@@ -3,13 +3,10 @@ package com.sparta.baedallegend.shop.controller.dto;
 import com.sparta.baedallegend.shop.domain.Shop;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ReadOneShopResponse {
 

--- a/src/main/java/com/sparta/baedallegend/shop/exception/ShopErrorCode.java
+++ b/src/main/java/com/sparta/baedallegend/shop/exception/ShopErrorCode.java
@@ -1,0 +1,19 @@
+package com.sparta.baedallegend.shop.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ShopErrorCode {
+	NOT_EXIST(NOT_FOUND, "요청에 해당하는 가게가 존재하지 않습니다. : [%s]");
+
+	private final HttpStatus status;
+	private final String message;
+
+	ShopErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/sparta/baedallegend/shop/exception/ShopException.java
+++ b/src/main/java/com/sparta/baedallegend/shop/exception/ShopException.java
@@ -1,0 +1,14 @@
+package com.sparta.baedallegend.shop.exception;
+
+import com.sparta.baedallegend.global.config.exception.BusinessException;
+
+public class ShopException extends BusinessException {
+
+	private final ShopErrorCode code;
+
+	public ShopException(ShopErrorCode code, Object... args) {
+		super(code.getStatus(), code.toString(), code.getMessage(), args);
+		this.code = code;
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/shop/service/ShopService.java
+++ b/src/main/java/com/sparta/baedallegend/shop/service/ShopService.java
@@ -13,6 +13,8 @@ import com.sparta.baedallegend.shop.controller.dto.ReadOneShopRequest;
 import com.sparta.baedallegend.shop.controller.dto.ReadOneShopResponse;
 import com.sparta.baedallegend.shop.domain.Shop;
 import com.sparta.baedallegend.shop.domain.ShopCategory;
+import com.sparta.baedallegend.shop.exception.ShopErrorCode;
+import com.sparta.baedallegend.shop.exception.ShopException;
 import com.sparta.baedallegend.shop.repo.ShopCategoryRepo;
 import com.sparta.baedallegend.shop.repo.ShopRepo;
 import com.sparta.baedallegend.user.domain.User;
@@ -72,11 +74,11 @@ public class ShopService {
 			.collect(Collectors.toList());
 
 		return new PageImpl<>(findAllShopResponses, pageRequest, shops.getSize());
-	} // TODO 페이징 처리 필요
+	}
 
 	public ReadOneShopResponse readOne(ReadOneShopRequest request) {
-		Shop shop = shopRepo.findById(UUID.fromString(request.getShopId())).orElseThrow(() ->
-			new IllegalArgumentException("존재하지 않는 상점입니다."));
+		Shop shop = shopRepo.findById(UUID.fromString(request.getShopId()))
+			.orElseThrow(() -> new ShopException(ShopErrorCode.NOT_EXIST, request.getShopId()));
 
 		List<Menu> menus = menuRepo.findByShopAndIsPublicTrue(shop);
 

--- a/src/main/java/com/sparta/baedallegend/shop/service/ShopService.java
+++ b/src/main/java/com/sparta/baedallegend/shop/service/ShopService.java
@@ -2,10 +2,15 @@ package com.sparta.baedallegend.shop.service;
 
 import com.sparta.baedallegend.category.domain.Category;
 import com.sparta.baedallegend.category.repo.CategoryRepo;
+import com.sparta.baedallegend.menu.domain.Menu;
+import com.sparta.baedallegend.menu.repo.MenuRepo;
 import com.sparta.baedallegend.region.domain.Region;
 import com.sparta.baedallegend.region.repo.RegionRepo;
 import com.sparta.baedallegend.shop.controller.dto.CreateShopRequest;
 import com.sparta.baedallegend.shop.controller.dto.FindAllShopResponse;
+import com.sparta.baedallegend.shop.controller.dto.ReadOneShopMenuResponse;
+import com.sparta.baedallegend.shop.controller.dto.ReadOneShopRequest;
+import com.sparta.baedallegend.shop.controller.dto.ReadOneShopResponse;
 import com.sparta.baedallegend.shop.domain.Shop;
 import com.sparta.baedallegend.shop.domain.ShopCategory;
 import com.sparta.baedallegend.shop.repo.ShopCategoryRepo;
@@ -32,6 +37,7 @@ public class ShopService {
 	private final CategoryRepo categoryRepo;
 	private final ShopCategoryRepo shopCategoryRepo;
 	private final RegionRepo regionRepo;
+	private final MenuRepo menuRepo;
 
 	@Transactional
 	public String create(Long userId, CreateShopRequest createShopRequest) {
@@ -67,5 +73,19 @@ public class ShopService {
 
 		return new PageImpl<>(findAllShopResponses, pageRequest, shops.getSize());
 	} // TODO 페이징 처리 필요
+
+	public ReadOneShopResponse readOne(ReadOneShopRequest request) {
+		Shop shop = shopRepo.findById(UUID.fromString(request.getShopId())).orElseThrow(() ->
+			new IllegalArgumentException("존재하지 않는 상점입니다."));
+
+		List<Menu> menus = menuRepo.findByShopAndIsPublicTrue(shop);
+
+		List<ReadOneShopMenuResponse> menuResponses = menus.stream()
+			.map(ReadOneShopMenuResponse::from).collect(
+				Collectors.toList());
+
+		ReadOneShopResponse response = ReadOneShopResponse.of(shop, menuResponses);
+		return response;
+	}
 
 }


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #47 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
Shop 단일 조회 API를 구현합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- Shop 단일 조회 API 구현에 필요한 DTO 구성
- 메뉴의 상태값 설명을 반환하기 위해 getter 메서드 추가
- 단일 조회에 필요한 Repo, Service, Controller 구현
- isPublic이 true인 메뉴들만 조회
- shop-api.http Shop 단일 조회 API 테스트 작성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> http 테스트 작성

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> Shop의 Menu들을 조회할 때 어떤 기준으로 정렬하여 조회할 것인지
> Shop Id가 너무 길고 못생겨서.. body로 넣었는데 어떻게 생각하시는지 궁금합니다.

## 종료할 이슈는 무엇인가요?

close #47 
