### PR TITLE
feat: 가게 검색 API

### DIFF
--- a/docs/client/shop-api.http
+++ b/docs/client/shop-api.http
@@ -18,10 +18,9 @@ GET http://localhost:8080/shop?page=0&size=2
 Authorization: Bearer {{access_token}}
 
 ### Shop 단일 조회 API
-GET http://localhost:8080/shop/details
+GET http://localhost:8080/shop/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3acb4
 Authorization: Bearer {{access_token}}
-Content-Type: application/json
 
-{
-  "shopId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3acb4"
-}
+### Shop 검색 API
+GET http://localhost:8080/shop/search?page=0&size=1
+Authorization: Bearer {{access_token}}

--- a/src/main/java/com/sparta/baedallegend/menu/repo/MenuRepo.java
+++ b/src/main/java/com/sparta/baedallegend/menu/repo/MenuRepo.java
@@ -5,6 +5,7 @@ import com.sparta.baedallegend.shop.domain.Shop;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,5 +13,7 @@ public interface MenuRepo extends JpaRepository<Menu, UUID> {
 
 	List<Menu> findByShopAndIsPublicTrue(Shop shop);
 
+	@Query("SELECT m FROM Menu m WHERE m.name LIKE %:keyword%")
+	List<Menu> findByNameLike(String keyword);
 
 }

--- a/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/ShopController.java
@@ -3,6 +3,7 @@ package com.sparta.baedallegend.shop.controller;
 import com.sparta.baedallegend.shop.controller.dto.CreateShopRequest;
 import com.sparta.baedallegend.shop.controller.dto.FindAllShopResponse;
 import com.sparta.baedallegend.shop.controller.dto.ReadOneShopResponse;
+import com.sparta.baedallegend.shop.controller.dto.SearchShopResponse;
 import com.sparta.baedallegend.shop.service.ShopService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -48,11 +49,23 @@ public class ShopController {
 		return ResponseEntity.ok().body(responses);
 	}
 
+	@GetMapping("/search")
+	public ResponseEntity<Page<SearchShopResponse>> search(
+		@RequestParam(value = "keyword", defaultValue = "") String keyword,
+		@RequestParam(value = "page", defaultValue = "0") int page,
+		@RequestParam(value = "size", defaultValue = "1") int size
+	) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+		Page<SearchShopResponse> responses = shopService.search(pageRequest, keyword);
+		return ResponseEntity.ok().body(responses);
+	}
+
 	@GetMapping("/{shopId}")
 	public ResponseEntity<ReadOneShopResponse> readOne(
 		@PathVariable(name = "shopId") String shopId) {
 		ReadOneShopResponse response = shopService.readOne(shopId);
 		return ResponseEntity.ok().body(response);
 	}
+
 
 }

--- a/src/main/java/com/sparta/baedallegend/shop/controller/dto/SearchShopResponse.java
+++ b/src/main/java/com/sparta/baedallegend/shop/controller/dto/SearchShopResponse.java
@@ -1,0 +1,37 @@
+package com.sparta.baedallegend.shop.controller.dto;
+
+import com.sparta.baedallegend.shop.domain.Shop;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchShopResponse {
+
+	private String id;
+	private String name;
+	private String description;
+	private String status;
+	private List<String> menuNames = new ArrayList<>();
+
+	private SearchShopResponse(String id, String name, String description, String status) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+		this.status = status;
+	}
+
+	public static SearchShopResponse from(Shop shop) {
+		return new SearchShopResponse(shop.getId().toString(), shop.getName(),
+			shop.getDescription(), shop.getStatus().getDescription());
+	}
+
+	public void addMenuName(String menuName) {
+		menuNames.add(menuName);
+	}
+
+
+}

--- a/src/main/java/com/sparta/baedallegend/shop/repo/ShopRepo.java
+++ b/src/main/java/com/sparta/baedallegend/shop/repo/ShopRepo.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,5 +22,8 @@ public interface ShopRepo extends JpaRepository<Shop, UUID> {
 		+ "WHEN s.status = 'CLOSED' THEN 3 "
 		+ "END")
 	Page<Shop> findByIsPublicTrue(PageRequest pageRequest);
+
+	@Query("SELECT s FROM Shop s WHERE s.name LIKE %:keyword%")
+	Page<Shop> findByNameLike(PageRequest pageRequest, @Param("keyword") String keyword);
 
 }


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #66

## ✏️ 작업한 내용을 간략히 설명해 주세요!
가게 검색 API를 구현합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 가게 검색 API 구현에 필요한 DTO 생성
- 키워드가 포함된 메뉴 검색을 위한 Repo 추가
- 키워드가 포함된 상점 검색을 위한 Repo 추가
- 필요한 Service, Controller 구현
- 가게 검색 API 테스트 작성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> http 테스트 작성

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

1. 현재 로직에서는 가게 이름에 키워드가 포함된 가게를 Page 객체로 받은 뒤 
또 따로 메뉴 이름에 키워드가 포함된 메뉴를 검색하여 `Response`에 추가하고 있습니다. 
그래서 `Pagerequest`로 요청한 size 보다 더 많게 불러오는 경우가 생깁니다.

2. 다른 방법으로는 `@Query` 어노테이션으로 직접 조인 쿼리를 날리는 방법인데
그렇게 되면 한 가게에 해당 키워드가 포함된 메뉴가 2개 이상 조회할 시에도 더 적게 불러오는 경우가 발생할 수 있습니다.
예를 들어 아래와 같이 size로 4를 요청했는데 가게는 3개만 불러오게 됩니다!!
![image](https://github.com/user-attachments/assets/faab4bcf-a5d4-47eb-bc1a-8d174b8b0f90)

제가 생각한 차선책은.. 프론트에게 그냥 전부 넘겨주기 입니다 ^^..
가게 검색 조회 결과는 배달의민족을 참고했습니다..!



## 📚 참고 자료

> [LIKE Query 작성법](https://recordsoflife.tistory.com/59)

---

## 종료할 이슈는 무엇인가요?

close #66
