### PR TITLE
feat: 회원 탈퇴 API 구현 및 TC 작성

### DIFF
--- a/docs/client/user-api.http
+++ b/docs/client/user-api.http
@@ -4,3 +4,10 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 ###
+
+## 회원 탈퇴 API
+DELETE http://localhost:8080/user/withdraw
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+###

--- a/src/main/java/com/sparta/baedallegend/user/controller/UserController.java
+++ b/src/main/java/com/sparta/baedallegend/user/controller/UserController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +30,13 @@ public class UserController {
 	ResponseEntity<UserResponse> me(@LoginUser Long id) {
 		log.info("[{}]", id);
 		return ResponseEntity.ok(userService.loadUserById(id));
+	}
+
+	@DeleteMapping("/withdraw")
+	ResponseEntity<Void> withdraw(@LoginUser Long id) {
+		log.info("[{}]", id);
+		userService.deleteUser(id);
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/src/main/java/com/sparta/baedallegend/user/service/UserService.java
+++ b/src/main/java/com/sparta/baedallegend/user/service/UserService.java
@@ -25,4 +25,10 @@ public class UserService {
 			.orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, id));
 	}
 
+	@Transactional
+	public void deleteUser(Long id) {
+		User user = findUser(id);
+		user.delete();
+	}
+
 }


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?
> #72 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
soft-delete 방식으로 CommonAuditingFields의 삭제 관련 필드인 updatedBy, updatedAt, isDeleted 항목을 업데이트 하여 회원 탈퇴 API를 구현하였습니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 회원 삭제를 위한 Service 및 Controller 메서드 추가
- 📌 Intellij http-client를 이용한 회원 탈퇴 API TC 작성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> Intellij http-client를 이용하여 회원 탈퇴 API 호출한 후, datagrip을 이용하여 is_deleted, updated_by, updated_at 컬럼의 항목이 변경됨을 확인하였습니다.

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> soft-delete 처리 시 deleted_at, deleted_by 항목을 업데이트 하기 위한 좋은 방법을 찾지 못하여, 삭제 여부를 표현하는 is_deleted 필드를 CommonAuditingFields에 추가하고 삭제 시간과 삭제 주체에 대한 내용은 updatedAt, updatedBy로 표현하고자 하였습니다. 리뷰에 참고 부탁드립니다.

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #70 
