### PR TITLE
build: query-dsl 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ db
 
 ## docker compose .env
 .env
+
+### Querydsl q-class
+src/main/generated/**

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,18 @@ repositories {
     mavenCentral()
 }
 
+def queryDslVersion = dependencyManagement.importedProperties["querydsl.version"]
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
@@ -50,7 +57,8 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-tasks.bootJar{
+// Jib configurations
+tasks.bootJar {
     archiveFileName.set("${project.name}")
 }
 
@@ -65,4 +73,22 @@ jib {
         mainClass = "com.sparta.baedallegend.BaedalLegendApp"
         creationTime = "USE_CURRENT_TIMESTAMP"
     }
+}
+
+// Query DSL configurations
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', 'src/main/generated']
+        }
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file('src/main/generated')
+    options.compilerArgs << "-Aquerydsl.generatedAnnotationClass=javax.annotation.Generated"
+}
+
+tasks.named('clean', Delete) {
+    delete file('src/main/generated')
 }

--- a/docs/client/user-api.http
+++ b/docs/client/user-api.http
@@ -5,6 +5,13 @@ Authorization: Bearer {{access_token}}
 
 ###
 
+## 회원 상세 조회 API
+GET http://localhost:8080/user/1
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+###
+
 ## 회원 탈퇴 API
 DELETE http://localhost:8080/user/withdraw
 Content-Type: application/json

--- a/src/main/java/com/sparta/baedallegend/domains/user/controller/UserController.java
+++ b/src/main/java/com/sparta/baedallegend/domains/user/controller/UserController.java
@@ -3,14 +3,15 @@ package com.sparta.baedallegend.domains.user.controller;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
 import com.sparta.baedallegend.domains.user.controller.model.UserResponse;
-import com.sparta.baedallegend.global.config.security.annotations.LoginUser;
 import com.sparta.baedallegend.domains.user.service.UserService;
+import com.sparta.baedallegend.global.config.security.annotations.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +32,12 @@ public class UserController {
 		log.info("[{}]", id);
 		return ResponseEntity.ok(userService.loadUserById(id));
 	}
+
+	@GetMapping("/{id}")
+	ResponseEntity<UserResponse> findUserById(@PathVariable Long id) {
+		return ResponseEntity.ok(userService.findUserById(id));
+	}
+
 
 	@DeleteMapping("/withdraw")
 	ResponseEntity<Void> withdraw(@LoginUser Long id) {

--- a/src/main/java/com/sparta/baedallegend/domains/user/controller/model/UserResponse.java
+++ b/src/main/java/com/sparta/baedallegend/domains/user/controller/model/UserResponse.java
@@ -1,6 +1,8 @@
 package com.sparta.baedallegend.domains.user.controller.model;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.sparta.baedallegend.domains.user.domain.User;
+
 
 public record UserResponse(
 	Long id,
@@ -9,6 +11,10 @@ public record UserResponse(
 	String roleDetails
 	// TODO Auditor 적용 후 가입일 응답 항목 추가
 ) {
+
+	@QueryProjection
+	public UserResponse {
+	}
 
 	public static UserResponse from(User user) {
 		return new UserResponse(

--- a/src/main/java/com/sparta/baedallegend/domains/user/repo/UserQueryRepo.java
+++ b/src/main/java/com/sparta/baedallegend/domains/user/repo/UserQueryRepo.java
@@ -1,0 +1,31 @@
+package com.sparta.baedallegend.domains.user.repo;
+
+import static com.sparta.baedallegend.domains.user.domain.QUser.user;
+
+import com.querydsl.jpa.JPQLQueryFactory;
+import com.sparta.baedallegend.domains.user.controller.model.QUserResponse;
+import com.sparta.baedallegend.domains.user.controller.model.UserResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepo {
+
+	private final JPQLQueryFactory queryFactory;
+
+	public Optional<UserResponse> findUserById(Long id) {
+		return Optional.ofNullable(queryFactory.select(
+				new QUserResponse(
+					user.id,
+					user.email,
+					user.nickname,
+					user.role.stringValue()
+				))
+			.from(user)
+			.where(user.id.eq(id))
+			.fetchOne());
+	}
+
+}

--- a/src/main/java/com/sparta/baedallegend/domains/user/service/UserService.java
+++ b/src/main/java/com/sparta/baedallegend/domains/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.sparta.baedallegend.domains.user.controller.model.UserResponse;
 import com.sparta.baedallegend.domains.user.domain.User;
 import com.sparta.baedallegend.domains.user.exception.UserErrorCode;
 import com.sparta.baedallegend.domains.user.exception.UserException;
+import com.sparta.baedallegend.domains.user.repo.UserQueryRepo;
 import com.sparta.baedallegend.domains.user.repo.UserRepo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
 	private final UserRepo userRepo;
+	private final UserQueryRepo userQueryRepo;
 
 	public UserResponse loadUserById(Long id) {
 		return UserResponse.from(findUser(id));
@@ -22,6 +24,11 @@ public class UserService {
 
 	public User findUser(Long id) {
 		return userRepo.findById(id)
+			.orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, id));
+	}
+
+	public UserResponse findUserById(Long id) {
+		return userQueryRepo.findUserById(id)
 			.orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, id));
 	}
 

--- a/src/main/java/com/sparta/baedallegend/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/sparta/baedallegend/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.baedallegend.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/src/test/java/com/sparta/baedallegend/domains/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/baedallegend/domains/auth/controller/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.sparta.baedallegend.auth.controller;
+package com.sparta.baedallegend.domains.auth.controller;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -11,7 +11,7 @@ import com.sparta.baedallegend.domains.auth.controller.model.SignInRequest;
 import com.sparta.baedallegend.domains.auth.controller.model.SignUpRequest;
 import com.sparta.baedallegend.domains.auth.service.AuthenticationService;
 import com.sparta.baedallegend.domains.auth.service.SignUpFacade;
-import com.sparta.baedallegend.base.WebMvcTestBase;
+import com.sparta.baedallegend.global.base.WebMvcTestBase;
 import com.sparta.baedallegend.domains.user.domain.Role;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/sparta/baedallegend/domains/user/repo/UserQueryRepoTest.java
+++ b/src/test/java/com/sparta/baedallegend/domains/user/repo/UserQueryRepoTest.java
@@ -1,0 +1,43 @@
+package com.sparta.baedallegend.domains.user.repo;
+
+import static com.sparta.baedallegend.global.fixture.UserFixtureGenerator.generateUserFixture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.baedallegend.global.base.JpaTestBase;
+import com.sparta.baedallegend.global.config.QueryDslTestConfig;
+import com.sparta.baedallegend.domains.user.controller.model.UserResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+
+@DisplayName("Query:Repo:User")
+@Import(QueryDslTestConfig.class)
+class UserQueryRepoTest extends JpaTestBase {
+
+	private final UserQueryRepo userQueryRepo;
+
+	public UserQueryRepoTest(UserQueryRepo userQueryRepo) {
+		this.userQueryRepo = userQueryRepo;
+	}
+
+	@BeforeEach
+	void setUp() {
+		entityManager.persist(generateUserFixture());
+		entityManager.flush();
+	}
+
+	@Test
+	@DisplayName("회원 조회")
+	void findMemberById() {
+		// When
+		UserResponse actual = Assertions.assertDoesNotThrow(
+			() -> userQueryRepo.findUserById(1L).orElseThrow()
+		);
+
+		// Then
+		assertThat(actual).isNotNull();
+	}
+
+}

--- a/src/test/java/com/sparta/baedallegend/domains/user/repo/UserRepoTest.java
+++ b/src/test/java/com/sparta/baedallegend/domains/user/repo/UserRepoTest.java
@@ -1,12 +1,11 @@
-package com.sparta.baedallegend.user.repo;
+package com.sparta.baedallegend.domains.user.repo;
 
-import static com.sparta.baedallegend.user.fixture.UserFixtureGenerator.generateUserFixture;
+import static com.sparta.baedallegend.global.fixture.UserFixtureGenerator.generateUserFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.sparta.baedallegend.base.JpaTestBase;
+import com.sparta.baedallegend.global.base.JpaTestBase;
 import com.sparta.baedallegend.domains.user.domain.User;
-import com.sparta.baedallegend.domains.user.repo.UserRepo;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/sparta/baedallegend/global/base/JpaTestBase.java
+++ b/src/test/java/com/sparta/baedallegend/global/base/JpaTestBase.java
@@ -1,7 +1,7 @@
-package com.sparta.baedallegend.base;
+package com.sparta.baedallegend.global.base;
 
 import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
-import com.sparta.baedallegend.config.P6spySqlFormatConfig;
+import com.sparta.baedallegend.global.config.P6spySqlFormatConfig;
 import com.sparta.baedallegend.global.config.jpa.JpaConfig;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
@@ -23,7 +23,7 @@ public abstract class JpaTestBase extends TestBase {
 	public static final String POSTGRES_IMAGE = "postgres:16.4";
 
 	@Resource
-	private EntityManager entityManager;
+	protected EntityManager entityManager;
 
 	protected void flushAndClear() {
 		entityManager.flush();

--- a/src/test/java/com/sparta/baedallegend/global/base/TestBase.java
+++ b/src/test/java/com/sparta/baedallegend/global/base/TestBase.java
@@ -1,6 +1,6 @@
-package com.sparta.baedallegend.base;
+package com.sparta.baedallegend.global.base;
 
-import static com.sparta.baedallegend.base.TestBase.TEST;
+import static com.sparta.baedallegend.global.base.TestBase.TEST;
 import static org.springframework.test.context.TestConstructor.AutowireMode.ALL;
 
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/com/sparta/baedallegend/global/base/WebMvcTestBase.java
+++ b/src/test/java/com/sparta/baedallegend/global/base/WebMvcTestBase.java
@@ -1,4 +1,4 @@
-package com.sparta.baedallegend.base;
+package com.sparta.baedallegend.global.base;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.baedallegend.domains.auth.controller.AuthController;

--- a/src/test/java/com/sparta/baedallegend/global/config/P6spySqlFormatConfig.java
+++ b/src/test/java/com/sparta/baedallegend/global/config/P6spySqlFormatConfig.java
@@ -1,4 +1,4 @@
-package com.sparta.baedallegend.config;
+package com.sparta.baedallegend.global.config;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.JdbcEventListener;

--- a/src/test/java/com/sparta/baedallegend/global/config/QueryDslTestConfig.java
+++ b/src/test/java/com/sparta/baedallegend/global/config/QueryDslTestConfig.java
@@ -1,0 +1,26 @@
+package com.sparta.baedallegend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.baedallegend.domains.user.repo.UserQueryRepo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslTestConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+	@Bean
+	public UserQueryRepo userQueryRepo() {
+		return new UserQueryRepo(jpaQueryFactory());
+	}
+
+}

--- a/src/test/java/com/sparta/baedallegend/global/fixture/UserFixtureGenerator.java
+++ b/src/test/java/com/sparta/baedallegend/global/fixture/UserFixtureGenerator.java
@@ -1,4 +1,4 @@
-package com.sparta.baedallegend.user.fixture;
+package com.sparta.baedallegend.global.fixture;
 
 import com.sparta.baedallegend.domains.user.domain.Role;
 import com.sparta.baedallegend.domains.user.domain.User;


### PR DESCRIPTION
## #️⃣ 해당 변경 사항과 연관된 이슈는 무엇인가요?

> #90 

## ✏️ 작업한 내용을 간략히 설명해 주세요!
가독성 있는 쿼리 작성을 위해 query-dsl 의존성을 추가하고, 필요한 설정을 적용하였습니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 query-dsl:5.1.0 의존성 추가
- 📌 QueryDsl 쿼리 작성을 위한 JpaQueryFactory 설정 추가
- 📌 QueryDsl을 이용한 회원 상세 조회 API 구현 및 QueryRepo TC 작성
- 📌 QueryRepo TC 작성을 위한 TestConfig 구성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> UserQueryRepoTest 작성, http-client를 이용한 회원 상세 조회 API 구현

## ✅ 해당 기능에 대한 테스트가 작성되었나요?

- [ ] 🟢 작성
- [x] 🟡 일부 구현
- [ ] 🔴 미 작성

## 💬 리뷰 요구사항

> query-dsl을 이용하여 간단한 회원 상세 조회 API를 구현하였습니다.
> - QueryDsl을 이용한 쿼리 작성은 해당 커밋에서 확인 하실 수 있습니다. [UserQueryRepo](https://github.com/baedal-legend/foody/pull/91/commits/a60149d38a306dd2a79b930f853e13425157b094)
> - QueryDsl을 통해 작성된 쿼리 TC는 해당 커밋에서 확인 하실 수 있습니다.[UserQueryRepoTest](https://github.com/baedal-legend/foody/pull/91/commits/9da9c4ce9c894109b468df04b7e508e7bafe45f5)
> 리뷰에 참고 부탁 드립니다.

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

## 종료할 이슈는 무엇인가요?

close #90 
